### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,7 @@
     "doxv"
   ],
   "author": "elaijuh <hjiale@gmail.com> (http://hujiale.me/)",
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/elaijuh/grunt-doxv/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/elaijuh/grunt-doxv/issues"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
